### PR TITLE
Added Jenkins Configuration-as-Code support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,15 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>structs</artifactId>
+        <version>1.2</version>
+      </dependency>
+    </dependencies>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/src/main/java/io/jenkins/plugins/logintheme/LoginTheme.java
+++ b/src/main/java/io/jenkins/plugins/logintheme/LoginTheme.java
@@ -94,12 +94,6 @@ public class LoginTheme extends SimplePageDecorator {
 
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        // reset values to default before data-binding
-        this.head = null;
-        this.header = null;
-        this.footer = null;
-        this.useDefaultTheme = true;
-
         req.bindJSON(this, json);
         this.save();
         return true;

--- a/src/main/java/io/jenkins/plugins/logintheme/LoginTheme.java
+++ b/src/main/java/io/jenkins/plugins/logintheme/LoginTheme.java
@@ -25,12 +25,16 @@ package io.jenkins.plugins.logintheme;
 
 import hudson.Extension;
 import jenkins.model.SimplePageDecorator;
+import hudson.model.Descriptor;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
 
 @Extension
+@Symbol("login-theme-plugin")
 public class LoginTheme extends SimplePageDecorator {
 
     private String head;
@@ -45,6 +49,7 @@ public class LoginTheme extends SimplePageDecorator {
         return useDefaultTheme;
     }
 
+    @DataBoundSetter
     public void setUseDefaultTheme(boolean useDefaultTheme) {
         this.useDefaultTheme = useDefaultTheme;
     }
@@ -68,23 +73,33 @@ public class LoginTheme extends SimplePageDecorator {
     }
 
     public LoginTheme() {
+        super();
         load();
     }
 
+    @DataBoundSetter
     public void setHead(String head) {
         this.head = head;
     }
 
+    @DataBoundSetter
     public void setHeader(String header) {
         this.header = header;
     }
 
+    @DataBoundSetter
     public void setFooter(String footer) {
         this.footer = footer;
     }
 
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        // reset values to default before data-binding
+        this.head = null;
+        this.header = null;
+        this.footer = null;
+        this.useDefaultTheme = true;
+
         req.bindJSON(this, json);
         this.save();
         return true;


### PR DESCRIPTION
Adding support for [Jenkins CasC plugin](https://github.com/jenkinsci/configuration-as-code-plugin). Based on work done for [simple-theme-plugin](https://github.com/jenkinsci/simple-theme-plugin/pull/2)