### PR TITLE
Move configuration to appearance page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ For example
 
 ![System config](docs/system_config.png)
 
+## Configuration as code
+
+```
+appearance:
+  simpleTheme:
+    footer: 'The footer'
+    head: ''
+    header: '<h3>Welcome to login theme Jenkins</h3>'
+    useDefaultTheme: true
+```
+
 ## Result
 
 Previous config will render login page customization

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For example
 
 ```
 appearance:
-  simpleTheme:
+  loginTheme:
     footer: 'The footer'
     head: ''
     header: '<h3>Welcome to login theme Jenkins</h3>'

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,9 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/login-theme-plugin</gitHubRepo>
-        <jenkins.version>2.414.1</jenkins.version>
+        <jenkins.version>2.421</jenkins.version>
+        <hpi.compatibleSinceVersion>46</hpi.compatibleSinceVersion>
+        <configuration-as-code.version>1670.v564dc8b_982d0</configuration-as-code.version>
     </properties>
     <name>Login Theme Plugin</name>
     <description>This plugin allows extending and overriding the default theme used on the login and signup pages since Jenkins 2.128.</description>
@@ -35,13 +37,27 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.414.x</artifactId>
+                <artifactId>bom-weekly</artifactId>
                 <version>2423.vce598171d115</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <scope>test</scope>
+          </dependency>
+          <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <scope>test</scope>
+          </dependency>
+    </dependencies>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/login-theme-plugin</gitHubRepo>
         <jenkins.version>2.421</jenkins.version>
-        <hpi.compatibleSinceVersion>46</hpi.compatibleSinceVersion>
+        <hpi.compatibleSinceVersion>78</hpi.compatibleSinceVersion>
         <configuration-as-code.version>1670.v564dc8b_982d0</configuration-as-code.version>
     </properties>
     <name>Login Theme Plugin</name>

--- a/src/main/java/io/jenkins/plugins/logintheme/LoginTheme.java
+++ b/src/main/java/io/jenkins/plugins/logintheme/LoginTheme.java
@@ -25,16 +25,20 @@ package io.jenkins.plugins.logintheme;
 
 import hudson.Extension;
 import jenkins.model.SimplePageDecorator;
-import hudson.model.Descriptor;
+import jenkins.appearance.AppearanceCategory;
+import jenkins.model.GlobalConfigurationCategory;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
 
 @Extension
-@Symbol("login-theme-plugin")
+@Symbol("loginTheme")
 public class LoginTheme extends SimplePageDecorator {
 
     private String head;
@@ -44,6 +48,12 @@ public class LoginTheme extends SimplePageDecorator {
     private String footer;
 
     private boolean useDefaultTheme = true;
+
+    @NonNull
+    @Override
+    public GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(AppearanceCategory.class);
+    }
 
     public boolean isUseDefaultTheme() {
         return useDefaultTheme;

--- a/src/test/java/io/jenkins/plugins/logintheme/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/logintheme/ConfigurationAsCodeTest.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.logintheme;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ConfigurationAsCodeTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    public void should_support_configuration_as_code() throws Exception {
+        LoginTheme plugin =Jenkins.get().getExtensionList(LoginTheme.class).get(0);
+        assertEquals(true, plugin.isUseDefaultTheme());
+        assertEquals("The footer", plugin.getFooter());
+        assertEquals("The head", plugin.getHead());
+        assertEquals("The header", plugin.getHeader());
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/logintheme/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/logintheme/configuration-as-code.yml
@@ -1,0 +1,6 @@
+appearance:
+  loginTheme:
+    footer: 'The footer'
+    head: 'The head'
+    header: 'The header'
+    useDefaultTheme: true


### PR DESCRIPTION
Requires:
https://github.com/jenkinsci/jenkins/pull/8403

~I would like to cut a release of this plugin before merging.~

Same as https://github.com/jenkinsci/simple-theme-plugin/pull/156

This add breaking change on the JCasC configuration

### Testing done

mvn hpi:run to check the page
automated test for new JCasC configuration (was never implemented)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
