### PR TITLE
Ensure correct bom version when jenkins version updated

### DIFF
--- a/updatecli/updatecli.d/update-jenkins-version.yml
+++ b/updatecli/updatecli.d/update-jenkins-version.yml
@@ -18,6 +18,21 @@ sources:
     github:
       token: '{{ requiredEnv .github.token }}'
       username: '{{ .github.username }}'
+  bom:
+    name: Get latest BOM line
+    kind: jenkins
+    spec:
+      release: weekly
+    transformers:
+      - trimsuffix: ".1"
+      - trimsuffix: ".2"
+      - trimsuffix: ".3"
+      - trimsuffix: ".4"
+      - addprefix: "bom-"
+      - addsuffix: ".x"
+    github:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ .github.username }}'
 targets:
   jenkins:
     name: Update Jenkins Version
@@ -28,13 +43,24 @@ targets:
       file: pom.xml
       matchpattern: '<jenkins.version>(.*)</jenkins.version>'
       replacepattern: '<jenkins.version>{{ source `jenkins` }}</jenkins.version>'
+  bom:
+    name: Ensure Jenkins BOM version
+    sourceid: jenkins
+    scmid: github
+    kind: file
+    spec:
+      file: pom.xml
+      matchpattern: '<artifactId>bom-(.*)</artifactId>'
+      replacepattern: '<artifactId>bom-weekly</artifactId>'
 actions:
   jenkins:
     title: Bump Jenkins version {{ source "jenkins" }}
+    disablepipelineurl: true
     kind: github/pullrequest
     scmid: github
     targets:
       - jenkins
+      - bom
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Ensure correct bom version when jenkins version updated

Need to be adapted when moving back to LTS line in some days

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
